### PR TITLE
Integrate stub_wisper_publisher rspec helper [Fix #1]

### DIFF
--- a/lib/wisper/rspec/stub_wisper_publisher.rb
+++ b/lib/wisper/rspec/stub_wisper_publisher.rb
@@ -1,0 +1,15 @@
+### Wisper Stubbing
+# This is a proposal for integration as part of wisper core
+# for testing: https://github.com/krisleech/wisper/issues/1
+class TestWisperPublisher
+  include Wisper
+  def initialize(*args); end
+end
+
+def stub_wisper_publisher(clazz, called_method, event_to_publish, *published_event_args)
+  stub_const(clazz, Class.new(TestWisperPublisher) do
+    define_method(called_method) do
+      publish(event_to_publish, *published_event_args)
+    end
+  end)
+end

--- a/spec/lib/rspec_extensions_spec.rb
+++ b/spec/lib/rspec_extensions_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+require 'wisper/rspec/stub_wisper_publisher'
+
+describe Wisper do
+  describe "given a piece of code invoking a publisher" do
+    class CodeThatReactsToEvents
+      def do_something
+        publisher = MyPublisher.new
+        publisher.on(:some_event) do |variable1, variable2|
+          return "Hello with #{variable1} #{variable2}!"
+        end
+        publisher.execute
+      end
+    end
+
+    context "when stubbing the publisher to emit an event" do
+      before do
+        stub_wisper_publisher("MyPublisher", :execute, :some_event, "foo1", "foo2")
+      end
+
+      it "emits the event" do
+        response = CodeThatReactsToEvents.new.do_something
+        response.should == "Hello with foo1 foo2!"
+      end
+    end
+  end
+end


### PR DESCRIPTION
As described in issue #1, a way to stub publishers to emit events. It's not really done as a proper rspec extension, but it does work. I want to research rspec extensions but it's pretty hairy stuff, so I'm going to pull request this as-is for now.
