### PR TITLE
Fix a potential threadsafe issue

### DIFF
--- a/lib/wisper/global_listeners.rb
+++ b/lib/wisper/global_listeners.rb
@@ -3,9 +3,12 @@ require 'singleton'
 module Wisper
   class GlobalListeners
     include Singleton
+    attr_reader :mutex
+    private :mutex
 
     def initialize
       @listeners = Set.new
+      @mutex     = Mutex.new
     end
 
     def add_listener(listener, options = {})
@@ -34,10 +37,6 @@ module Wisper
     end
 
     private
-
-    def mutex
-      @mutex ||= Mutex.new
-    end
 
     def with_mutex
       mutex.synchronize { yield }


### PR DESCRIPTION
Lazily setting @mutex could lead to have two mutexes with a sample code
like:

``` ruby
[MyListener.new, MailListener.new].each do |listener|
  Thread.new {
    Wisper::GlobalListeners.add_listener(listener)
  }
end
```

This example is cumbersome, but well, it shows the idea. Even with a
singleton, if `add_listener` is called a first time by two different
threads, this could lead to thread safety issues for ruby implementation
without a gvl.

Signed-off-by: chatgris jboyer@af83.com
