### PR TITLE
Update gem version used in README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ models.
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'wisper', '~>1.0.0'
+gem 'wisper', '~>1.2.0'
 ```
 
 ## Usage


### PR DESCRIPTION
Using the old 1.0.0 gem doesn't work, as Wisper::Publisher doesn't exist. 
