### PR TITLE
Allow to register global listeners with options.

### DIFF
--- a/lib/wisper.rb
+++ b/lib/wisper.rb
@@ -17,7 +17,7 @@ module Wisper
     TemporaryListeners.with(*args, &block)
   end
 
-  def self.add_listener(listener)
-    GlobalListeners.add(listener)
+  def self.add_listener(listener, options = {})
+    GlobalListeners.add(listener, options)
   end
 end

--- a/spec/lib/global_subscribers_spec.rb
+++ b/spec/lib/global_subscribers_spec.rb
@@ -12,6 +12,15 @@ describe Wisper::GlobalListeners do
       publisher.send(:broadcast, :it_happened)
     end
 
+    it 'works with options' do
+      Wisper::GlobalListeners.add(global_listener, :on => :it_happened,
+                                                   :with => :woot)
+      global_listener.should_receive(:woot).once
+      global_listener.should_not_receive(:it_happened_again)
+      publisher.send(:broadcast, :it_happened)
+      publisher.send(:broadcast, :it_happened_again)
+    end
+
     it 'works along side local listeners' do
       # global listener
       Wisper::GlobalListeners.add(global_listener)


### PR DESCRIPTION
Well, why not? This makes registering global listeners more consistent with local ones.
For me this was handy for example for building an audit log.
