### PR TITLE
Allow stubbed publisher method to accept arbitrary args

### DIFF
--- a/lib/wisper/rspec/stub_wisper_publisher.rb
+++ b/lib/wisper/rspec/stub_wisper_publisher.rb
@@ -8,7 +8,7 @@ end
 
 def stub_wisper_publisher(clazz, called_method, event_to_publish, *published_event_args)
   stub_const(clazz, Class.new(TestWisperPublisher) do
-    define_method(called_method) do
+    define_method(called_method) do |*args|
       publish(event_to_publish, *published_event_args)
     end
   end)


### PR DESCRIPTION
With this, using the readme's example, you could do `publisher.execute(arg1, arg2, …)` without getting a "wrong number of arguments" error from RSpec
