### PR TITLE
Updated specs to pass under rspec-3

### DIFF
--- a/spec/lib/global_subscribers_spec.rb
+++ b/spec/lib/global_subscribers_spec.rb
@@ -54,7 +54,7 @@ describe Wisper::GlobalListeners do
     end
 
     it 'returns an immutable collection' do
-      Wisper::GlobalListeners.listeners.frozen?.should be_true
+      Wisper::GlobalListeners.listeners.should be_frozen
       expect { Wisper::GlobalListeners.listeners << global_listener }.to raise_error(RuntimeError)
     end
   end

--- a/spec/lib/wisper/publisher_spec.rb
+++ b/spec/lib/wisper/publisher_spec.rb
@@ -21,7 +21,7 @@ describe Wisper::Publisher do
         listener.stub(:so_did_this)
         listener.should_not_receive(:so_did_this)
 
-        listener.respond_to?(:so_did_this).should be_true
+        listener.should respond_to(:so_did_this)
 
         publisher.add_listener(listener, :on => 'this_happened')
 
@@ -35,7 +35,7 @@ describe Wisper::Publisher do
         listener.stub(:so_did_this)
         listener.should_not_receive(:so_did_this)
 
-        listener.respond_to?(:so_did_this).should be_true
+        listener.should respond_to(:so_did_this)
 
         publisher.add_listener(listener, :on => ['this_happened', 'and_this'])
 
@@ -81,7 +81,7 @@ describe Wisper::Publisher do
     end
 
     it 'is aliased to .subscribe' do
-      publisher.respond_to?(:subscribe).should be_true
+      publisher.should respond_to(:subscribe)
     end
   end
 
@@ -190,7 +190,7 @@ describe Wisper::Publisher do
 
   describe '.listeners' do
     it 'returns an immutable collection' do
-      publisher.listeners.frozen?.should be_true
+      publisher.listeners.should be_frozen
       expect { publisher.listeners << listener }.to raise_error(RuntimeError)
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,11 +7,19 @@ end
 require 'wisper'
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
   config.order = 'random'
   config.after(:each) { Wisper::GlobalListeners.clear }
+
+  # Support both Rspec2 should and Rspec3 expect syntax
+  config.expect_with :rspec do |c|
+    c.syntax = [:should, :expect]
+  end
+
+  config.mock_with :rspec do |c|
+    c.syntax = [:should, :expect]
+  end
 end
 
 # returns an anonymous wispered class

--- a/wisper.gemspec
+++ b/wisper.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency 'rspec'
+  gem.add_development_dependency 'rspec', "~> 3.0.0.beta1"
 end


### PR DESCRIPTION
The spec changes are actually rspec2 backwards compatible, although the config changes in the spec helper are for rspec3. This is a prerequisite to further work I plan to do to get stub_wisper_publisher to support argument checking, which is an rspec 3 feature. Thanks @krisleech!
