### PR TITLE
Convert the specs to use the `expect` syntax instead of the `should` syntax

### DIFF
--- a/spec/lib/global_subscribers_spec.rb
+++ b/spec/lib/global_subscribers_spec.rb
@@ -8,15 +8,15 @@ describe Wisper::GlobalListeners do
   describe '.add' do
     it 'adds given listener to every publisher' do
       Wisper::GlobalListeners.add(global_listener)
-      global_listener.should_receive(:it_happened)
+      expect(global_listener).to receive(:it_happened)
       publisher.send(:broadcast, :it_happened)
     end
 
     it 'works with options' do
       Wisper::GlobalListeners.add(global_listener, :on => :it_happened,
                                                    :with => :woot)
-      global_listener.should_receive(:woot).once
-      global_listener.should_not_receive(:it_happened_again)
+      expect(global_listener).to receive(:woot).once
+      expect(global_listener).not_to receive(:it_happened_again)
       publisher.send(:broadcast, :it_happened)
       publisher.send(:broadcast, :it_happened_again)
     end
@@ -28,8 +28,8 @@ describe Wisper::GlobalListeners do
       # local listener
       publisher.add_listener(local_listener)
 
-      global_listener.should_receive(:it_happened)
-      local_listener.should_receive(:it_happened)
+      expect(global_listener).to receive(:it_happened)
+      expect(local_listener).to receive(:it_happened)
 
       publisher.send(:broadcast, :it_happened)
     end
@@ -42,9 +42,9 @@ describe Wisper::GlobalListeners do
       Wisper::GlobalListeners.add(global_listener, :scope => [publisher_1.class,
                                                               publisher_2.class])
 
-      global_listener.should_receive(:it_happened_1).once
-      global_listener.should_receive(:it_happened_2).once
-      global_listener.should_not_receive(:it_happened_3)
+      expect(global_listener).to receive(:it_happened_1).once
+      expect(global_listener).to receive(:it_happened_2).once
+      expect(global_listener).not_to receive(:it_happened_3)
 
       publisher_1.send(:broadcast, :it_happened_1)
       publisher_2.send(:broadcast, :it_happened_2)
@@ -60,18 +60,18 @@ describe Wisper::GlobalListeners do
         end
       end.each(&:join)
 
-      Wisper::GlobalListeners.listeners.size.should == num_threads
+      expect(Wisper::GlobalListeners.listeners.size).to eq num_threads
     end
   end
 
   describe '.listeners' do
     it 'returns collection of global listeners' do
       Wisper::GlobalListeners.add(global_listener)
-      Wisper::GlobalListeners.listeners.should == [global_listener]
+      expect(Wisper::GlobalListeners.listeners).to eq [global_listener]
     end
 
     it 'returns an immutable collection' do
-      Wisper::GlobalListeners.listeners.should be_frozen
+      expect(Wisper::GlobalListeners.listeners).to be_frozen
       expect { Wisper::GlobalListeners.listeners << global_listener }.to raise_error(RuntimeError)
     end
   end
@@ -79,14 +79,14 @@ describe Wisper::GlobalListeners do
   it '.clear clears all global listeners' do
     Wisper::GlobalListeners.add(global_listener)
     Wisper::GlobalListeners.clear
-    Wisper::GlobalListeners.listeners.should be_empty
+    expect(Wisper::GlobalListeners.listeners).to be_empty
   end
 
   describe 'backwards compatibility' do
     it '.add_listener adds a listener' do
       silence_warnings do
         Wisper::GlobalListeners.add_listener(global_listener)
-        global_listener.should_receive(:it_happened)
+        expect(global_listener).to receive(:it_happened)
         publisher.send(:broadcast, :it_happened)
       end
     end

--- a/spec/lib/integration_spec.rb
+++ b/spec/lib/integration_spec.rb
@@ -17,7 +17,7 @@ describe Wisper do
 
   it 'subscribes object to all published events' do
     listener = double('listener')
-    listener.should_receive(:success).with('hello')
+    expect(listener).to receive(:success).with('hello')
 
     command = MyCommand.new
 
@@ -28,7 +28,7 @@ describe Wisper do
 
   it 'subscribes block to all published events' do
     insider = double('Insider')
-    insider.should_receive(:render).with('hello')
+    expect(insider).to receive(:render).with('hello')
 
     command = MyCommand.new
 
@@ -42,8 +42,8 @@ describe Wisper do
   it 'maps events to different methods' do
     listener_1 = double('listener')
     listener_2 = double('listener')
-    listener_1.should_receive(:happy_days).with('hello')
-    listener_2.should_receive(:sad_days).with('world')
+    expect(listener_1).to receive(:happy_days).with('hello')
+    expect(listener_2).to receive(:sad_days).with('world')
 
     command = MyCommand.new
 
@@ -57,8 +57,8 @@ describe Wisper do
   it 'subscribes block can be chained' do
     insider = double('Insider')
 
-    insider.should_receive(:render).with('success')
-    insider.should_receive(:render).with('failure')
+    expect(insider).to receive(:render).with('success')
+    expect(insider).to receive(:render).with('failure')
 
     command = MyCommand.new
 

--- a/spec/lib/rspec_extensions_spec.rb
+++ b/spec/lib/rspec_extensions_spec.rb
@@ -20,7 +20,7 @@ describe Wisper do
 
       it "emits the event" do
         response = CodeThatReactsToEvents.new.do_something
-        response.should == "Hello with foo1 foo2!"
+        expect(response).to eq "Hello with foo1 foo2!"
       end
     end
   end

--- a/spec/lib/simple_example_spec.rb
+++ b/spec/lib/simple_example_spec.rb
@@ -13,8 +13,8 @@ end
 describe 'simple publishing' do
   it 'subscribes listener to events' do
     listener = double('listener')
-    listener.should_receive(:foo).with instance_of MyPublisher
-    listener.should_receive(:bar).with instance_of MyPublisher
+    expect(listener).to receive(:foo).with instance_of MyPublisher
+    expect(listener).to receive(:bar).with instance_of MyPublisher
 
     my_publisher = MyPublisher.new
     my_publisher.add_listener(listener)

--- a/spec/lib/wisper/publisher_spec.rb
+++ b/spec/lib/wisper/publisher_spec.rb
@@ -6,8 +6,8 @@ describe Wisper::Publisher do
 
   describe '.add_listener' do
     it 'subscribes given listener to all published events' do
-      listener.should_receive(:this_happened)
-      listener.should_receive(:so_did_this)
+      expect(listener).to receive(:this_happened)
+      expect(listener).to receive(:so_did_this)
 
       publisher.add_listener(listener)
 
@@ -17,11 +17,11 @@ describe Wisper::Publisher do
 
     describe ':on argument' do
       it 'subscribes given listener to a single event' do
-        listener.should_receive(:this_happened)
-        listener.stub(:so_did_this)
-        listener.should_not_receive(:so_did_this)
+        expect(listener).to receive(:this_happened)
+        allow(listener).to receive(:so_did_this)
+        expect(listener).not_to receive(:so_did_this)
 
-        listener.should respond_to(:so_did_this)
+        expect(listener).to respond_to(:so_did_this)
 
         publisher.add_listener(listener, :on => 'this_happened')
 
@@ -30,12 +30,12 @@ describe Wisper::Publisher do
       end
 
       it 'subscribes given listener to many events' do
-        listener.should_receive(:this_happened)
-        listener.should_receive(:and_this)
-        listener.stub(:so_did_this)
-        listener.should_not_receive(:so_did_this)
+        expect(listener).to receive(:this_happened)
+        expect(listener).to receive(:and_this)
+        allow(listener).to receive(:so_did_this)
+        expect(listener).not_to receive(:so_did_this)
 
-        listener.should respond_to(:so_did_this)
+        expect(listener).to respond_to(:so_did_this)
 
         publisher.add_listener(listener, :on => ['this_happened', 'and_this'])
 
@@ -47,7 +47,7 @@ describe Wisper::Publisher do
 
     describe ':with argument' do
       it 'sets method to call listener with on event' do
-        listener.should_receive(:different_method).twice
+        expect(listener).to receive(:different_method).twice
 
         publisher.add_listener(listener, :with => :different_method)
 
@@ -58,8 +58,8 @@ describe Wisper::Publisher do
 
     describe ':prefix argument' do
       it 'prefixes broadcast events with given symbol' do
-        listener.should_receive(:after_it_happened)
-        listener.should_not_receive(:it_happened)
+        expect(listener).to receive(:after_it_happened)
+        expect(listener).not_to receive(:it_happened)
 
         publisher.add_listener(listener, :prefix => :after)
 
@@ -67,8 +67,8 @@ describe Wisper::Publisher do
       end
 
       it 'prefixes broadcast events with "on" when given true' do
-        listener.should_receive(:on_it_happened)
-        listener.should_not_receive(:it_happened)
+        expect(listener).to receive(:on_it_happened)
+        expect(listener).not_to receive(:it_happened)
 
         publisher.add_listener(listener, :prefix => true)
 
@@ -79,23 +79,23 @@ describe Wisper::Publisher do
     # NOTE: these are not realistic use cases, since you would only ever use
     # `scope` when globally subscribing.
     describe ':scope argument' do
-      let(:listener_1) {double('Listener')  }
-      let(:listener_2) {double('Listener')  }
+      let(:listener_1) { double('Listener') }
+      let(:listener_2) { double('Listener') }
 
       before do
       end
 
       it 'scopes listener to given class' do
-        listener_1.should_receive(:it_happended)
-        listener_2.should_not_receive(:it_happended)
+        expect(listener_1).to receive(:it_happended)
+        expect(listener_2).not_to receive(:it_happended)
         publisher.add_listener(listener_1, :scope => publisher.class)
         publisher.add_listener(listener_2, :scope => Class.new)
         publisher.send(:broadcast, 'it_happended')
       end
 
       it 'scopes listener to given class string' do
-        listener_1.should_receive(:it_happended)
-        listener_2.should_not_receive(:it_happended)
+        expect(listener_1).to receive(:it_happended)
+        expect(listener_2).not_to receive(:it_happended)
         publisher.add_listener(listener_1, :scope => publisher.class.to_s)
         publisher.add_listener(listener_2, :scope => Class.new.to_s)
         publisher.send(:broadcast, 'it_happended')
@@ -106,7 +106,7 @@ describe Wisper::Publisher do
         publisher_sub_klass = Class.new(publisher_super_klass)
 
         listener = double('Listener')
-        listener.should_receive(:it_happended).once
+        expect(listener).to receive(:it_happended).once
 
         publisher = publisher_sub_klass.new
 
@@ -116,11 +116,12 @@ describe Wisper::Publisher do
     end
 
     it 'returns publisher so methods can be chained' do
-      publisher.add_listener(listener, :on => 'so_did_this').should == publisher
+      expect(publisher.add_listener(listener, :on => 'so_did_this')).to \
+        eq publisher
     end
 
     it 'is aliased to .subscribe' do
-      publisher.should respond_to(:subscribe)
+      expect(publisher).to respond_to(:subscribe)
     end
   end
 
@@ -128,7 +129,7 @@ describe Wisper::Publisher do
     let(:insider) { double('insider') }
 
     it 'subscribes given block to all events' do
-      insider.should_receive(:it_happened).twice
+      expect(insider).to receive(:it_happened).twice
 
       publisher.add_block_listener do
         insider.it_happened
@@ -140,7 +141,7 @@ describe Wisper::Publisher do
 
     describe ':on argument' do
       it '.add_block_listener subscribes block to an event' do
-        insider.should_not_receive(:it_happened).once
+        expect(insider).not_to receive(:it_happened).once
 
         publisher.add_block_listener(:on => 'something_happened') do
           insider.it_happened
@@ -151,7 +152,7 @@ describe Wisper::Publisher do
       end
 
       it '.add_block_listener subscribes block to all listed events' do
-        insider.should_receive(:it_happened).twice
+        expect(insider).to receive(:it_happened).twice
 
         publisher.add_block_listener(
           :on => ['something_happened', 'and_so_did_this']) do
@@ -165,8 +166,8 @@ describe Wisper::Publisher do
     end
 
     it 'returns publisher so methods can be chained' do
-      publisher.add_block_listener(:on => 'this_thing_happened') do
-      end.should == publisher
+      expect(publisher.add_block_listener(:on => 'this_thing_happened') do
+      end).to eq publisher
     end
   end
 
@@ -174,7 +175,7 @@ describe Wisper::Publisher do
     let(:insider) { double('insider') }
 
     it 'subscribes given block to an event' do
-      insider.should_receive(:it_happened)
+      expect(insider).to receive(:it_happened)
 
       publisher.on(:something_happened) do
         insider.it_happened
@@ -184,7 +185,7 @@ describe Wisper::Publisher do
     end
 
     it 'subscribes given block to multiple events' do
-      insider.should_receive(:it_happened).twice
+      expect(insider).to receive(:it_happened).twice
 
       publisher.on(:something_happened, :and_so_did_this) do
         insider.it_happened
@@ -198,8 +199,8 @@ describe Wisper::Publisher do
 
   describe '.broadcast' do
     it 'does not publish events which cannot be responded to' do
-      listener.should_not_receive(:so_did_this)
-      listener.stub(:respond_to? => false)
+      expect(listener).not_to receive(:so_did_this)
+      allow(listener).to receive(:respond_to?).and_return(false)
 
       publisher.add_listener(listener, :on => 'so_did_this')
 
@@ -208,7 +209,7 @@ describe Wisper::Publisher do
 
     describe ':event argument' do
       it 'is indifferent to string and symbol' do
-        listener.should_receive(:this_happened).twice
+        expect(listener).to receive(:this_happened).twice
 
         publisher.add_listener(listener)
 
@@ -217,7 +218,7 @@ describe Wisper::Publisher do
       end
 
       it 'is indifferent to dasherized and underscored strings' do
-        listener.should_receive(:this_happened).twice
+        expect(listener).to receive(:this_happened).twice
 
         publisher.add_listener(listener)
 
@@ -229,14 +230,14 @@ describe Wisper::Publisher do
 
   describe '.listeners' do
     it 'returns an immutable collection' do
-      publisher.listeners.should be_frozen
+      expect(publisher.listeners).to be_frozen
       expect { publisher.listeners << listener }.to raise_error(RuntimeError)
     end
 
     it 'returns local listeners' do
        publisher.add_listener(listener)
-       publisher.listeners.should == [listener]
-       publisher.listeners.size.should == 1
+       expect(publisher.listeners).to eq [listener]
+       expect(publisher.listeners.size).to eq 1
     end
   end
 
@@ -246,13 +247,13 @@ describe Wisper::Publisher do
 
     it 'subscribes listeners to all instances of publisher' do
       publisher_klass_1.add_listener(listener)
-      listener.should_receive(:it_happened).once
+      expect(listener).to receive(:it_happened).once
       publisher_klass_1.new.send(:broadcast, 'it_happened')
       publisher_klass_2.new.send(:broadcast, 'it_happened')
     end
 
     it 'is aliased to #subscribe' do
-      publisher_klass_1.should respond_to(:subscribe)
+      expect(publisher_klass_1).to respond_to(:subscribe)
     end
   end
 end

--- a/spec/lib/wisper_spec.rb
+++ b/spec/lib/wisper_spec.rb
@@ -5,7 +5,7 @@ describe Wisper do
   it 'includes Wisper::Publisher for backwards compatibility' do
     silence_warnings do
       publisher_class = Class.new { include Wisper }
-      publisher_class.ancestors.should include Wisper::Publisher
+      expect(publisher_class.ancestors).to include Wisper::Publisher
     end
   end
 
@@ -13,8 +13,8 @@ describe Wisper do
     publisher = publisher_class.new
     listener = double('listener')
 
-    listener.should_receive(:im_here)
-    listener.should_not_receive(:not_here)
+    expect(listener).to receive(:im_here)
+    expect(listener).not_to receive(:not_here)
 
     Wisper.with_listeners(listener) do
       publisher.send(:broadcast, 'im_here')
@@ -26,6 +26,6 @@ describe Wisper do
   it '.add_listener adds a global listener' do
     listener = double('listener')
     Wisper.add_listener(listener)
-    Wisper::GlobalListeners.listeners.should == [listener]
+    expect(Wisper::GlobalListeners.listeners).to eq [listener]
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,11 +11,11 @@ RSpec.configure do |config|
 
   # Support both Rspec2 should and Rspec3 expect syntax
   config.expect_with :rspec do |c|
-    c.syntax = [:should, :expect]
+    c.syntax = :expect
   end
 
   config.mock_with :rspec do |c|
-    c.syntax = [:should, :expect]
+    c.syntax = :expect
   end
 end
 


### PR DESCRIPTION
Remove the `should` syntax from spec_helper to only use `expect` syntax from now on
Fix all the specs to use the `expect` syntax instead of the `should` syntax.

reference issue #47 
