### PR TITLE
rails backward compatibility with respond_to

### DIFF
--- a/lib/wisper/publisher.rb
+++ b/lib/wisper/publisher.rb
@@ -18,6 +18,7 @@ module Wisper
 
     # sugar
     def respond_to(*events, &block)
+      super unless events.any? && block_given?
       add_block_listener({:on => events}, &block)
     end
 


### PR DESCRIPTION
This allows using either Wisper's respond_to and Rail's original respond_to, so existing code such as this won't break:

``` ruby
    respond_to do |format|
        format.html { ... }
        format.json { ... }
    end
```
