### PR TITLE
alias global and temporary listener methods to "subscribe" for consistancy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Authors: Kris Leech, Marc Ignacio, Ahmed Abdel Razzak, kmehkeri, Jake Hoffner
 * fix: temporary global listeners are cleared if an exception is raised
 * refactor: update all specs to rspec 3 expect syntax
 * docs: update README to rspec 3 expect syntax
+* enhancement: alias global and temporary listener methods to `.subscribe`
+* enhancement: add deprecation warning for old aliased methods
 
 ## 1.3.0 (18th Jan 2014)
 

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ obvious on reading the code and of course you are introducing global state and
 'always on' behaviour. This may not desirable.
 
 ```ruby
-Wisper.add_listener(MyListener.new)
+Wisper.subscribe(MyListener.new)
 ```
 
 In a Rails app you might want to add your global listeners in an initalizer.
@@ -220,7 +220,7 @@ You might want to globally subscribe a listener to publishers with a certain
 class.
 
 ```ruby
-Wisper.add_listener(MyListener.new, scope: :MyPublisher)
+Wisper.subscribe(MyListener.new, scope: :MyPublisher)
 ```
 
 This will subscribe the listener to all instances of `MyPublisher` and its
@@ -229,7 +229,7 @@ subclasses.
 Alternatively you can also do exactly the same with a publisher class:
 
 ```ruby
-MyPublisher.add_listener(MyListener.new)
+MyPublisher.subscribe(MyListener.new)
 ```
 
 ## Temporary Global Listeners
@@ -237,7 +237,7 @@ MyPublisher.add_listener(MyListener.new)
 You can also globally subscribe listeners for the duration of a block.
 
 ```ruby
-Wisper.with_listeners(MyListener.new, OtherListener.new) do
+Wisper.subscribe(MyListener.new, OtherListener.new) do
   # do stuff
 end
 ```

--- a/lib/wisper.rb
+++ b/lib/wisper.rb
@@ -14,10 +14,23 @@ module Wisper
   end
 
   def self.with_listeners(*args, &block)
-    TemporaryListeners.with(*args, &block)
+    warn "[DEPRECATION] `use Wisper.subscribe` instead of `Wisper.with_listeners`"
+    self.subscribe(*args, &block)
   end
 
   def self.add_listener(listener, options = {})
-    GlobalListeners.add(listener, options)
+    warn "[DEPRECATION] `use Wisper.subscribe` instead of `Wisper.add_listener`"
+    self.subscribe(listener, options)
+  end
+
+  def self.subscribe(*args, &block)
+    if block_given?
+      TemporaryListeners.with(*args, &block)
+    else
+      options = args.last.is_a?(Hash) ? args.pop : {}
+      args.each do |listener|
+        GlobalListeners.add(listener, options)
+      end
+    end
   end
 end

--- a/spec/lib/async_spec.rb
+++ b/spec/lib/async_spec.rb
@@ -5,6 +5,6 @@ describe 'async option' do
   let(:publisher) { publisher_class.new }
 
   it 'it raises a deprecation exception' do
-      expect { publisher.add_listener(listener, :async => true) }.to raise_error
+    expect { publisher.add_listener(listener, :async => true) }.to raise_error
   end
 end

--- a/spec/lib/wisper_spec.rb
+++ b/spec/lib/wisper_spec.rb
@@ -1,31 +1,82 @@
 require 'spec_helper'
 
 describe Wisper do
-
-  it 'includes Wisper::Publisher for backwards compatibility' do
-    silence_warnings do
-      publisher_class = Class.new { include Wisper }
-      expect(publisher_class.ancestors).to include Wisper::Publisher
-    end
+  before do
+    # assign the stderr to a new StringIO to test errors
+    @orig_stderr, $stderr = $stderr, StringIO.new
   end
 
+  after do
+    # reassign the stderr to the original <IO:<STDERR>> instead of StringIO
+    # used for testing
+    $stderr = @orig_stderr
+  end
+
+  it 'includes Wisper::Publisher for backwards compatibility' do
+    publisher_class = Class.new { include Wisper }
+    expect(publisher_class.ancestors).to include Wisper::Publisher
+
+    $stderr.rewind
+    expect($stderr.gets.chomp).to include 'DEPRECATION'
+  end
+
+  # NOTE .with_listeners is deprecated
   it '.with_listeners subscribes listeners to all broadcast events for the duration of block' do
     publisher = publisher_class.new
     listener = double('listener')
-
-    expect(listener).to receive(:im_here)
-    expect(listener).not_to receive(:not_here)
 
     Wisper.with_listeners(listener) do
       publisher.send(:broadcast, 'im_here')
     end
 
-    publisher.send(:broadcast, 'not_here')
+    $stderr.rewind
+    expect($stderr.string.chomp).to include 'DEPRECATION'
   end
 
+  # NOTE .add_listener is deprecated
   it '.add_listener adds a global listener' do
     listener = double('listener')
+
     Wisper.add_listener(listener)
-    expect(Wisper::GlobalListeners.listeners).to eq [listener]
+
+    $stderr.rewind
+    expect($stderr.string.chomp).to include 'DEPRECATION'
+  end
+
+  describe '.subscribe' do
+    context 'given block' do
+      it 'subscribes listeners to all events for duration of the block' do
+        publisher = publisher_class.new
+        listener = double('listener')
+
+        expect(listener).to receive(:im_here)
+        expect(listener).not_to receive(:not_here)
+
+        Wisper.subscribe(listener) do
+          publisher.send(:broadcast, 'im_here')
+        end
+
+        publisher.send(:broadcast, 'not_here')
+      end
+    end
+
+    context 'no block given' do
+      it 'subscribes a listener to all events' do
+        listener = double('listener')
+        Wisper.subscribe(listener)
+        expect(Wisper::GlobalListeners.listeners).to eq [listener]
+      end
+
+      it 'subscribes multiple listeners to all events' do
+        listener_1 = double('listener')
+        listener_2 = double('listener')
+        listener_3 = double('listener')
+
+        Wisper.subscribe(listener_1, listener_2)
+
+        expect(Wisper::GlobalListeners.listeners).to include listener_1, listener_2
+        expect(Wisper::GlobalListeners.listeners).not_to include listener_3
+      end
+    end
   end
 end


### PR DESCRIPTION
responding to issue #66

Please note that I'm not that experienced with the gem, so I added a this PR draft to discuss and complete the issue.
I also suspect that the testing I've done is not sufficient.
and I'm sure that the testing is not DRY... maybe moving the specs of all the 3 methods (`.subscribe`, `.with_listeners`, `.add_listener`) to a [shared examples](https://www.relishapp.com/rspec/rspec-core/docs/example-groups/shared-examples) be better -which I plan to do before merging-
