### PR TITLE
add `with` option to rspec matcher

### DIFF
--- a/lib/wisper/rspec/matchers.rb
+++ b/lib/wisper/rspec/matchers.rb
@@ -12,18 +12,26 @@ module Wisper
       end
 
       def method_missing(method_name, *args, &block)
-        @broadcast_events << method_name.to_s
+        @broadcast_events << Event.new(method_name.to_s, args)
       end
 
-      def broadcast?(event_name)
-        @broadcast_events.include?(event_name.to_s)
+      def broadcast?(event_name, args = nil)
+        if args.nil?
+          !!@broadcast_events.find { |event| event.name == event_name.to_s }
+        else
+          @broadcast_events.include?(Event.new(event_name.to_s, args))
+        end
       end
+
+      # TODO: make === equality string/symbol agnostic for name
+      class Event < Struct.new(:name, :args); end
     end
 
     module BroadcastMatcher
       class Matcher
-        def initialize(event)
-          @event = event
+        def initialize(event_name, options)
+          @event = event_name
+          @args  = options.key?(:with) ? Array(options[:with]) : nil
         end
 
         def supports_block_expectations?
@@ -37,20 +45,30 @@ module Wisper
             block.call
           end
 
-          event_recorder.broadcast?(@event)
+          event_recorder.broadcast?(@event, @args)
         end
 
         def failure_message
-          "expected publisher to broadcast #{@event} event"
+          message = "expected publisher to broadcast #{@event} event"
+          message << " with arguments #{@args.join(', ')}" if with_args?
+          message
         end
 
         def failure_message_when_negated
-          "expected publisher not to broadcast #{@event} event"
+          message = "expected publisher not to broadcast #{@event} event"
+          message << " with arguments #{@args.join(', ')}" if with_args?
+          message
+        end
+
+        private
+
+        def with_args?
+          !@args.nil?
         end
       end
 
-      def broadcast(event)
-        Matcher.new(event)
+      def broadcast(event_name, options = {})
+        Matcher.new(event_name, options)
       end
     end
   end

--- a/spec/lib/wisper/rspec/matchers_spec.rb
+++ b/spec/lib/wisper/rspec/matchers_spec.rb
@@ -15,4 +15,9 @@ describe 'broadcast matcher' do
     publisher = publisher_class.new
     expect { publisher }.not_to broadcast(:foobar)
   end
+
+  it 'passes when publisher broadcasts with given arguments' do
+    publisher = publisher_class.new
+    expect { publisher.send(:broadcast, :foobar, :arg1) }.to broadcast(:foobar, with: :arg1)
+  end
 end


### PR DESCRIPTION
This adds a `with` option to the rspec matcher which asserts on the arguments broadcast. If does not use chained matchers such as 

``` ruby
expect { publisher.execute }.to broadcast(:event_name).with(arg1, arg2)
```

This is  because this requires the block to be yielded twice, once for `broadcast` matcher and once for the `with` matcher (and once for other chained matchers like `once`). This problem is potentially fixed in rspec 3.1 , but it is not yet beta. 

So for now while not very rspec-y we can have an optional inline `with` option on the `broadcast` matcher such as:

``` ruby
expect { publisher.execute }.to broadcast(:event_name, with: [arg1, arg2])
```
