### PR TITLE
Add Wisper.clear to clear all global listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,15 @@ stub_wisper_publisher("MyPublisher", :execute, :some_event, "foo1", "foo2", ...)
 
 See `spec/lib/rspec_extensions_spec.rb` for a runnable example.
 
+## Clearing Global Listeners
+
+If you use global listeners in non-feature tests you _might_ want to clear them
+in a hook to prevent global subscriptions persisting between tests.
+
+```ruby
+after { Wisper.clear }
+```
+
 ## Compatibility
 
 Tested with MRI 1.9.x, MRI 2.0.0, JRuby (1.9 and 2.0 mode) and Rubinius (1.9

--- a/lib/wisper.rb
+++ b/lib/wisper.rb
@@ -41,6 +41,10 @@ module Wisper
     Publisher
   end
 
+  def self.clear
+    GlobalListeners.clear
+  end
+
   def self.configure
     yield(configuration)
   end

--- a/spec/lib/wisper_spec.rb
+++ b/spec/lib/wisper_spec.rb
@@ -82,6 +82,12 @@ describe Wisper do
     expect(Wisper.publisher).to eq Wisper::Publisher
   end
 
+  it '.clear clears all global listeners' do
+    10.times { Wisper.subscribe(double) }
+    Wisper.clear
+    expect(Wisper::GlobalListeners.listeners).to be_empty
+  end
+
   it '.configuration returns configuration' do
     expect(Wisper.configuration).to be_an_instance_of(Wisper::Configuration)
   end


### PR DESCRIPTION
Allows alternative to `Wisper::GlobalListeners.clear` which is `Wisper.clear`.
