### PR TITLE
Allow including of `Wisper.publisher` as well as `Wisper::Publisher`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ end
 
 When a publisher broadcasts an event it can include number of arguments. 
 
-The `broadcast` method is also aliased as `publish` and `emit`.
+The `broadcast` method is also aliased as `publish` and `announce`.
+
+You can also include `Wisper.publisher` instead of `Wisper::Publisher`.
 
 ### Subscribing
 

--- a/lib/wisper.rb
+++ b/lib/wisper.rb
@@ -37,6 +37,10 @@ module Wisper
     end
   end
 
+  def self.publisher
+    Publisher
+  end
+
   def self.configure
     yield(configuration)
   end

--- a/spec/lib/wisper_spec.rb
+++ b/spec/lib/wisper_spec.rb
@@ -78,6 +78,10 @@ describe Wisper do
     end
   end
 
+  it '.publisher returns the Publisher module' do
+    expect(Wisper.publisher).to eq Wisper::Publisher
+  end
+
   it '.configuration returns configuration' do
     expect(Wisper.configuration).to be_an_instance_of(Wisper::Configuration)
   end


### PR DESCRIPTION
Allows a slightly (subjectively) nicer synatx for including the Publisher module.

``` ruby
class MyPublisher
  include Wisper.publisher

  # ...
end
```
