### PR TITLE
Drop support for Ruby 1.9.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 bundler_args: --without=extras
 script: rspec spec
 rvm:
-  - '1.9.2'
   - '1.9.3'
   - '2.0.0'
   - '2.1.2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * remove deprecated methods
 * remove rspec matcher and stubbing (moved to [wisper-rspec](https://github.com/krisleech/wisper-rspec))
+* drop support for Ruby 1.9.2
 
 ## 1.6.0 (25 Oct 2014)
 

--- a/README.md
+++ b/README.md
@@ -270,8 +270,7 @@ after { Wisper.clear }
 
 ## Compatibility
 
-Tested with MRI 1.9.x, MRI 2.0.0, JRuby (1.9 and 2.0 mode) and Rubinius (1.9
-mode).
+Tested with MRI 1.9.3, MRI 2.1, JRuby and Rubinius.
 
 See the [build status](https://travis-ci.org/krisleech/wisper) for details.
 

--- a/wisper.gemspec
+++ b/wisper.gemspec
@@ -8,10 +8,12 @@ Gem::Specification.new do |gem|
   gem.version       = Wisper::VERSION
   gem.authors       = ["Kris Leech"]
   gem.email         = ["kris.leech@gmail.com"]
-  gem.description   = %q{pub/sub for Ruby objects}
-  gem.summary       = %q{pub/sub for Ruby objects}
+  gem.description   = 'A micro library providing Ruby objects with Publish-Subscribe capabilities'
+  gem.summary       = 'A micro library providing Ruby objects with Publish-Subscribe capabilities'
   gem.homepage      = "https://github.com/krisleech/wisper"
   gem.license       = "MIT"
+
+  gem.required_ruby_version = '>= 1.9.3'
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
Drop support for Ruby 1.9.2 which is now EOL since June.

Users of 1.9.2 will still be able to use version 1.0 of Wisper.

This is a breaking change.
