### PR TITLE
Test harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,9 +255,43 @@ report_creator.subscribe(MailResponder.new, on:   :create_report_failed,
 You could also alias the method within your listener, as such
 `alias successful create_report_successful`.
 
-## RSpec
+## Testing
 
-### Broadcast Matcher
+### Test harness
+
+Wisper allows you to dynamically configure the testing harness with the following methods:
+
+``` ruby
+require 'wisper/testing'
+Wisper::Testing.enable! # this is the default
+Wisper::Testing.disable!
+```
+
+Each of the above methods also accepts a block. An example:
+
+``` ruby
+require 'wisper/testing'
+Wisper::Testing.disable!
+
+# Some tests
+
+Wisper::Testing.enable! do
+  # Some other tests that rely on Wisper
+end
+
+# Here we're back to "disabled" mode again.
+```
+
+To query the current state, use the following methods:
+
+``` ruby
+Wisper::Testing.enabled?
+Wisper::Testing.disabled?
+```
+
+### RSpec
+
+#### Broadcast Matcher
 
 ```ruby
 require 'wisper/rspec/matchers'
@@ -269,7 +303,7 @@ end
 expect { publisher.execute }.to broadcast(:an_event)
 ```
 
-### Using message expections
+#### Using message expections
 
 If you need to assert on the arguments broadcast you can subscribe a double 
 with a [message expection](https://github.com/rspec/rspec-mocks#message-expectations)
@@ -285,7 +319,7 @@ publisher.subscribe(listener)
 publisher.execute
 ```
 
-### Stubbing publishers
+#### Stubbing publishers
 
 You can stub publishers and their events in unit (isolated) tests that only care about reacting to events.
 
@@ -334,7 +368,7 @@ stub_wisper_publisher("MyPublisher", :execute, :some_event, "foo1", "foo2", ...)
 
 See `spec/lib/rspec_extensions_spec.rb` for a runnable example.
 
-## Clearing Global Listeners
+### Clearing Global Listeners
 
 If you use global listeners in non-feature tests you _might_ want to clear them
 in a hook to prevent global subscriptions persisting between tests.

--- a/lib/wisper/rspec/matchers.rb
+++ b/lib/wisper/rspec/matchers.rb
@@ -1,3 +1,4 @@
+require 'wisper/testing'
 require 'rspec/expectations'
 
 module Wisper
@@ -33,9 +34,7 @@ module Wisper
         def matches?(block)
           event_recorder = EventRecorder.new
 
-          Wisper.subscribe(event_recorder) do
-            block.call
-          end
+          Wisper::Publisher.with_testing_event_recorder(event_recorder, &block)
 
           event_recorder.broadcast?(@event)
         end

--- a/lib/wisper/testing.rb
+++ b/lib/wisper/testing.rb
@@ -49,6 +49,10 @@ module Wisper
       end
     end
 
+    def wisper_subscribed_locally?(listener)
+      local_registrations.any? { |registration| registration.listener == listener }
+    end
+
     class << self
       def record_testing_event(event, *args)
         @testing_event_recorder.send(event, *args) if @testing_event_recorder
@@ -62,6 +66,22 @@ module Wisper
           @testing_event_recorder = nil
         end
       end
+    end
+  end
+
+  class << self
+    def registrations
+      GlobalListeners.registrations + TemporaryListeners.registrations
+    end
+
+    def subscribed?(listener)
+      registrations.any? { |reg| reg.listener == listener }
+    end
+
+    def subscribed_to_publisher?(listener, publisher)
+      registrations.any? { |reg|
+        reg.listener == listener && reg.allowed_classes.include?(publisher.to_s)
+      }
     end
   end
 end

--- a/lib/wisper/testing.rb
+++ b/lib/wisper/testing.rb
@@ -27,20 +27,12 @@ module Wisper
         __set_test_mode(:disable, &block)
       end
 
-      def fake!(&block)
-        __set_test_mode(:fake, &block)
-      end
-
       def enabled?
         self.__test_mode != :disable
       end
 
       def disabled?
         self.__test_mode == :disable
-      end
-
-      def fake?
-        self.__test_mode == :fake
       end
     end
   end
@@ -50,10 +42,10 @@ module Wisper
 
     def broadcast(event, *args)
       Publisher.record_testing_event(event, *args)
-      if Wisper::Testing.fake?
-        true
-      else
+      if Wisper::Testing.enabled?
         broadcast_real(event, *args)
+      else
+        true
       end
     end
 

--- a/lib/wisper/testing.rb
+++ b/lib/wisper/testing.rb
@@ -1,0 +1,75 @@
+require 'wisper'
+
+module Wisper
+  class Testing
+    class << self
+      attr_accessor :__test_mode
+
+      def __set_test_mode(mode, &block)
+        if block
+          current_mode = self.__test_mode
+          begin
+            self.__test_mode = mode
+            block.call
+          ensure
+            self.__test_mode = current_mode
+          end
+        else
+          self.__test_mode = mode
+        end
+      end
+
+      def enable!(&block)
+        __set_test_mode(:enabled, &block)
+      end
+
+      def disable!(&block)
+        __set_test_mode(:disable, &block)
+      end
+
+      def fake!(&block)
+        __set_test_mode(:fake, &block)
+      end
+
+      def enabled?
+        self.__test_mode != :disable
+      end
+
+      def disabled?
+        self.__test_mode == :disable
+      end
+
+      def fake?
+        self.__test_mode == :fake
+      end
+    end
+  end
+
+  module Publisher
+    alias_method :broadcast_real, :broadcast
+
+    def broadcast(event, *args)
+      Publisher.record_testing_event(event, *args)
+      if Wisper::Testing.fake?
+        true
+      else
+        broadcast_real(event, *args)
+      end
+    end
+
+    class << self
+      def record_testing_event(event, *args)
+        @testing_event_recorder.send(event, *args) if @testing_event_recorder
+      end
+
+      def with_testing_event_recorder(event_recorder)
+        @testing_event_recorder = event_recorder
+        begin
+          yield
+        ensure
+          @testing_event_recorder = nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
*These changes are specific to version 1.0 of wisper. I want to work on a port of these for 2.0, but since we're currently using wisper with these changes, I want to contribute them immediately.*

Add a test harness which allows us to use Wisper in a project with extensive specs. This is modeled after `Sidekiq::Testing`. It modifies the `Wisper` and `Wisper::Publisher` modules to allow the following:

1. Testing whether subscriptions exist.
2. Running actions in a project that publish events, but without delivering the events.

In order to use this, a project will need to include the testing module:

```ruby
require 'wisper/testing'
```

The `Wisper::Testing` module and its use are described in the README.

And modify the built-in rspec matcher to support it. The rspec matcher will be removed in wisper 2.0, but I updated it anyway. I'm also working on a pull request for the widget-rspec project that relies on these changes, and I'll post a link here when it's done.