### PR TITLE
Test harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,29 +263,29 @@ Wisper allows you to dynamically configure the testing harness with the followin
 
 ``` ruby
 require 'wisper/testing'
-Wisper::Testing.enable! # this is the default
-Wisper::Testing.disable!
+Wisper::Testing.disable! # this is the default, no change in Wisper functionality
+Wisper::Testing.fake! # in this mode, events broadcasted are not delivered to listeners
 ```
 
 Each of the above methods also accepts a block. An example:
 
 ``` ruby
 require 'wisper/testing'
-Wisper::Testing.disable!
+Wisper::Testing.fake!
 
-# Some tests
+# Some tests that do not require wisper events to be received
 
-Wisper::Testing.enable! do
+Wisper::Testing.disable! do
   # Some other tests that rely on Wisper
 end
 
-# Here we're back to "disabled" mode again.
+# Here we're back to "fake" mode again.
 ```
 
 To query the current state, use the following methods:
 
 ``` ruby
-Wisper::Testing.enabled?
+Wisper::Testing.fake?
 Wisper::Testing.disabled?
 ```
 

--- a/README.md
+++ b/README.md
@@ -255,11 +255,45 @@ report_creator.subscribe(MailResponder.new, on:   :create_report_failed,
 You could also alias the method within your listener, as such
 `alias successful create_report_successful`.
 
-## RSpec
+## Testing
+
+### Test harness
+
+Wisper allows you to dynamically configure the testing harness with the following methods:
+
+``` ruby
+require 'wisper/testing'
+Wisper::Testing.enable! # this is the default
+Wisper::Testing.disable!
+```
+
+Each of the above methods also accepts a block. An example:
+
+``` ruby
+require 'wisper/testing'
+Wisper::Testing.disable!
+
+# Some tests
+
+Wisper::Testing.enable! do
+  # Some other tests that rely on Wisper
+end
+
+# Here we're back to "disabled" mode again.
+```
+
+To query the current state, use the following methods:
+
+``` ruby
+Wisper::Testing.enabled?
+Wisper::Testing.disabled?
+```
+
+### RSpec
 
 Please see [wisper-rspec](https://github.com/krisleech/wisper-rspec).
 
-## Clearing Global Listeners
+### Clearing Global Listeners
 
 If you use global listeners in non-feature tests you _might_ want to clear them
 in a hook to prevent global subscriptions persisting between tests.

--- a/lib/wisper/testing.rb
+++ b/lib/wisper/testing.rb
@@ -94,9 +94,9 @@ module Wisper
     end
 
     # Determines whether an object is registered as a listener for a specific publisher object.
-    def subscribed_to_publisher?(listener, publisher)
+    def subscribed_to_publisher?(listener, publisher_class)
       registrations.any? { |reg|
-        reg.listener == listener && reg.allowed_classes.include?(publisher.to_s)
+        reg.listener == listener && reg.allowed_classes.include?(publisher_class.to_s)
       }
     end
   end

--- a/lib/wisper/testing.rb
+++ b/lib/wisper/testing.rb
@@ -19,12 +19,12 @@ module Wisper
         end
       end
 
-      def enable!(&block)
-        __set_test_mode(:enabled, &block)
-      end
-
       def disable!(&block)
         __set_test_mode(:disable, &block)
+      end
+
+      def fake!(&block)
+        __set_test_mode(:fake, &block)
       end
 
       def enabled?
@@ -33,6 +33,10 @@ module Wisper
 
       def disabled?
         self.__test_mode == :disable
+      end
+
+      def fake?
+        self.__test_mode == :fake
       end
     end
   end
@@ -45,10 +49,10 @@ module Wisper
     # delivery of the event.
     def broadcast(event, *args)
       Publisher.record_testing_event(event, *args)
-      if Wisper::Testing.enabled?
-        broadcast_real(event, *args)
-      else
+      if Wisper::Testing.fake?
         true
+      else
+        broadcast_real(event, *args)
       end
     end
     alias_method :publish, :broadcast

--- a/lib/wisper/testing.rb
+++ b/lib/wisper/testing.rb
@@ -49,6 +49,10 @@ module Wisper
       end
     end
 
+    def wisper_subscribed_locally?(listener)
+      local_registrations.any? { |registration| registration.listener == listener }
+    end
+
     class << self
       def record_testing_event(event, *args)
         @testing_event_recorder.send(event, *args) if @testing_event_recorder
@@ -62,6 +66,22 @@ module Wisper
           @testing_event_recorder = nil
         end
       end
+    end
+  end
+
+  class << self
+    def registrations
+      GlobalListeners.registrations + TemporaryListeners.registrations
+    end
+
+    def subscribed?(listener)
+      registrations.any? { |reg| reg.listener == listener }
+    end
+
+    def subscribed_to_publisher?(listener, publisher)
+      registrations.any? { |reg|
+        reg.listener == listener && reg.allowed_classes.include?(publisher.to_s)
+      }
     end
   end
 end

--- a/lib/wisper/testing.rb
+++ b/lib/wisper/testing.rb
@@ -27,20 +27,12 @@ module Wisper
         __set_test_mode(:disable, &block)
       end
 
-      def fake!(&block)
-        __set_test_mode(:fake, &block)
-      end
-
       def enabled?
         self.__test_mode != :disable
       end
 
       def disabled?
         self.__test_mode == :disable
-      end
-
-      def fake?
-        self.__test_mode == :fake
       end
     end
   end
@@ -50,10 +42,10 @@ module Wisper
 
     def broadcast(event, *args)
       Publisher.record_testing_event(event, *args)
-      if Wisper::Testing.fake?
-        true
-      else
+      if Wisper::Testing.enabled?
         broadcast_real(event, *args)
+      else
+        true
       end
     end
 

--- a/lib/wisper/testing.rb
+++ b/lib/wisper/testing.rb
@@ -54,8 +54,10 @@ module Wisper
     end
 
     class << self
+      attr_reader :testing_event_recorder
+
       def record_testing_event(event, *args)
-        @testing_event_recorder.send(event, *args) if @testing_event_recorder
+        testing_event_recorder.send(event, *args) if testing_event_recorder
       end
 
       def with_testing_event_recorder(event_recorder)

--- a/lib/wisper/testing.rb
+++ b/lib/wisper/testing.rb
@@ -1,0 +1,75 @@
+require 'wisper'
+
+module Wisper
+  class Testing
+    class << self
+      attr_accessor :__test_mode
+
+      def __set_test_mode(mode, &block)
+        if block
+          current_mode = self.__test_mode
+          begin
+            self.__test_mode = mode
+            block.call
+          ensure
+            self.__test_mode = current_mode
+          end
+        else
+          self.__test_mode = mode
+        end
+      end
+
+      def enable!(&block)
+        __set_test_mode(:enabled, &block)
+      end
+
+      def disable!(&block)
+        __set_test_mode(:disable, &block)
+      end
+
+      def fake!(&block)
+        __set_test_mode(:fake, &block)
+      end
+
+      def enabled?
+        self.__test_mode != :disable
+      end
+
+      def disabled?
+        self.__test_mode == :disable
+      end
+
+      def fake?
+        self.__test_mode == :fake
+      end
+    end
+  end
+
+  module Publisher
+    alias_method :broadcast_real, :broadcast
+
+    def broadcast(event, *args)
+      Publisher.record_testing_event(event, *args)
+      if Wisper::Testing.fake?
+        true
+      else
+        broadcast_real(event, *args)
+      end
+    end
+
+    class << self
+      def record_testing_event(event, *args)
+        @testing_event_recorder.send(event, *args) if @testing_event_recorder
+      end
+
+      def with_testing_event_recorder(event_recorder)
+        @testing_event_recorder = event_recorder
+        begin
+          yield
+        ensure
+          @testing_event_recorder = nil
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/testing_spec.rb
+++ b/spec/lib/testing_spec.rb
@@ -60,18 +60,18 @@ if ENV['INCLUDE_WISPER_TESTING']
         expect(event_recorder).to receive(:event_name).with(:arg1, :arg2)
         subject
       end
-      context 'with Wisper::Testing.enabled (the default)' do
+      context 'with Wisper::Testing.disabled! (the default)' do
         it 'publishes the event' do
           expect(listener).to receive(:event_name).with(:arg1, :arg2)
           subject
         end
       end
-      context 'with Wisper::Testing.disabled' do
+      context 'with Wisper::Testing.fake!' do
         before do
-          Wisper::Testing.disable!
+          Wisper::Testing.fake!
         end
         after do
-          Wisper::Testing.enable!
+          Wisper::Testing.disable!
         end
         it 'does not publish the event' do
           expect(listener).not_to receive(:event_name).with(:arg1, :arg2)

--- a/spec/lib/testing_spec.rb
+++ b/spec/lib/testing_spec.rb
@@ -1,8 +1,34 @@
-if ENV['INCLUDE_WISPER_TESTING']
-  describe Wisper::Testing do
-    let(:our_publisher_class) { publisher_class }
-    let(:publisher) { our_publisher_class.new }
-    let(:listener) { double('listener', event_name: true) }
+ENV['SKIP_WISPER_TESTING_PATCH'] = 'true'
+require 'wisper/testing'
+
+describe 'Wisper::Testing' do
+  let(:our_publisher_class) { publisher_class }
+  let(:publisher) { our_publisher_class.new }
+  let(:listener) { double('listener', event_name: true) }
+
+  context 'after patching and unpatching' do
+    before do
+      Wisper::Testing.patch!
+      Wisper::Testing.unpatch!
+      Wisper::Testing.fake!
+    end
+    after do
+      Wisper::Testing.disable!
+    end
+    it 'uses the original broadcast method' do
+      publisher.subscribe(listener)
+      publisher.send(:broadcast, 'event_name', :arg1, :arg2)
+      expect(listener).to have_received(:event_name).with(:arg1, :arg2)
+    end
+  end
+
+  context 'while Wisper is patched' do
+    before do
+      Wisper::Testing.patch!
+    end
+    after do
+      Wisper::Testing.unpatch!
+    end
 
     describe 'Wisper::Publisher.wisper_subscribed_locally?' do
       subject { publisher.wisper_subscribed_locally?(listener) }

--- a/spec/lib/testing_spec.rb
+++ b/spec/lib/testing_spec.rb
@@ -1,0 +1,83 @@
+if ENV['INCLUDE_WISPER_TESTING']
+  describe Wisper::Testing do
+    let(:our_publisher_class) { publisher_class }
+    let(:publisher) { our_publisher_class.new }
+    let(:listener) { double('listener', event_name: true) }
+
+    describe 'Wisper::Publisher.wisper_subscribed_locally?' do
+      subject { publisher.wisper_subscribed_locally?(listener) }
+
+      context 'when the listener is not registered' do
+        it { is_expected.to be_falsey }
+      end
+      context 'when the listener is registered' do
+        before do
+          publisher.subscribe(listener)
+        end
+        it { is_expected.to be_truthy }
+      end
+    end
+
+    describe 'Wisper.subscribed?' do
+      subject { Wisper.subscribed?(listener) }
+
+      context 'when the listener is not registered' do
+        it { is_expected.to be_falsey }
+      end
+      context 'when the listener is registered' do
+        before do
+          Wisper.subscribe(listener)
+        end
+        it { is_expected.to be_truthy }
+      end
+    end
+
+    describe 'Wisper.subscribed_to_publisher?' do
+      subject { Wisper.subscribed_to_publisher?(listener, our_publisher_class) }
+
+      context 'when the listener is not registered' do
+        it { is_expected.to be_falsey }
+      end
+      context 'when the listener is registered' do
+        before do
+          our_publisher_class.subscribe(listener)
+        end
+        it { is_expected.to be_truthy }
+      end
+    end
+
+    describe 'Wisper.with_testing_event_recorder' do
+      let(:event_recorder) { double('event_recorder', event_name: true) }
+      before do
+        publisher.subscribe(listener)
+      end
+      subject {
+        Wisper::Publisher.with_testing_event_recorder(event_recorder) do
+          publisher.send(:broadcast, 'event_name', :arg1, :arg2)
+        end
+      }
+      it 'records the event' do
+        expect(event_recorder).to receive(:event_name).with(:arg1, :arg2)
+        subject
+      end
+      context 'with Wisper::Testing.enabled (the default)' do
+        it 'publishes the event' do
+          expect(listener).to receive(:event_name).with(:arg1, :arg2)
+          subject
+        end
+      end
+      context 'with Wisper::Testing.disabled' do
+        before do
+          Wisper::Testing.disable!
+        end
+        after do
+          Wisper::Testing.enable!
+        end
+        it 'does not publish the event' do
+          expect(listener).not_to receive(:event_name).with(:arg1, :arg2)
+          subject
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,10 +3,6 @@ Coveralls.wear!
 
 require 'wisper'
 
-if ENV['INCLUDE_WISPER_TESTING']
-  require 'wisper/testing'
-end
-
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run :focus

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,10 @@ Coveralls.wear!
 
 require 'wisper'
 
+if ENV['INCLUDE_WISPER_TESTING']
+  require 'wisper/testing'
+end
+
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run :focus


### PR DESCRIPTION
Add a test harness which allows us to use Wisper in a project with extensive specs. This is modeled after [Sidekiq::Testing](https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/testing.rb). It modifies the `Wisper` and `Wisper::Publisher` modules to allow the following:

1. Testing whether subscriptions exist.
2. Running actions in a project that publish events, but without necessarily delivering the events.

In order to use this, a project's tests (e.g. `spec_helper`) will need to include the testing module:

```ruby
require 'wisper/testing'
```

The `Wisper::Testing` module and its use are described in the README. The default mode of the testing module is to change no functionality. "Fake" mode is enabled by calling `Wisper::Testing.fake!`. If called with a block, the mode change is only effective during the block's execution.

We wouldn't want the Wisper classes/modules to be polluted by the testing module, so 'wisper/testing' is not included during normal operation. So I did not modify the existing specs by including 'wisper/testing'.

In order to ensure that this new module works correctly and doesn't break the existing Wisper functionality, it would be necessary to run the spec suite twice: one with Wisper::Testing and one without. The default behavior is to run without, which can be changed by setting the `INCLUDE_WISPER_TESTING` environment variable. Therefore it would be best to have CI run the spec twice, the second time with that variable set.

Unfortunately, this would cause the test coverage to be wrong and/or reported twice per build. I think it might be best to only run the specs a single time and allow the testing module to be included randomly based on rspec's seed. This seems to be how the sidekiq project does it, but they're using Minitest, so it's not clear to me whether it works exactly the same.