### PR TITLE
Add support for unsubscribing a global listener

### DIFF
--- a/lib/wisper.rb
+++ b/lib/wisper.rb
@@ -33,6 +33,10 @@ module Wisper
     end
   end
 
+  def self.unsubscribe(*listeners)
+    GlobalListeners.unsubscribe(*listeners)
+  end
+
   def self.publisher
     Publisher
   end

--- a/lib/wisper/global_listeners.rb
+++ b/lib/wisper/global_listeners.rb
@@ -24,6 +24,15 @@ module Wisper
       self
     end
 
+    def unsubscribe(*listeners)
+      with_mutex do
+        @registrations.delete_if do |registration|
+          listeners.include?(registration.listener)
+        end
+      end
+      self
+    end
+
     def registrations
       with_mutex { @registrations }
     end
@@ -38,6 +47,10 @@ module Wisper
 
     def self.subscribe(*listeners)
       instance.subscribe(*listeners)
+    end
+
+    def self.unsubscribe(*listeners)
+      instance.unsubscribe(*listeners)
     end
 
     def self.registrations

--- a/spec/lib/wisper_spec.rb
+++ b/spec/lib/wisper_spec.rb
@@ -35,6 +35,29 @@ describe Wisper do
     end
   end
 
+  describe '.unsubscribe' do
+    it 'removes listener from list of listeners' do
+      listener = double('listener')
+
+      Wisper.subscribe(listener)
+      expect(Wisper::GlobalListeners.listeners).to eq [listener]
+
+      Wisper.unsubscribe(listener)
+      expect(Wisper::GlobalListeners.listeners).to eq []
+    end
+
+    it 'removes listeners from list of listeners' do
+      listener_1 = double('listener')
+      listener_2 = double('listener')
+
+      Wisper.subscribe(listener_1, listener_2)
+      expect(Wisper::GlobalListeners.listeners).to include listener_1, listener_2
+
+      Wisper.unsubscribe(listener_1, listener_2)
+      expect(Wisper::GlobalListeners.listeners).to eq []
+    end
+  end
+
   describe '.publisher' do
     it 'returns the Publisher module' do
       expect(Wisper.publisher).to eq Wisper::Publisher


### PR DESCRIPTION
This PR adds support for unsubscribing a Global Listener. I'm using Wisper across several Rails Engines and a Rails app. One of the Rails engines is subscribing to a listener that the Rails app does not need so I would like to be able to unsubscribe from that listener. I'm not able to modify the Rails engine because several Rails apps make use of it.

I thought about adding support for the "block" syntax, but I don't have a use for this currently and I was unsure of what the semantics of that would be.