### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ broadcast. However it can be mapped to a different method using `with:`.
 report_creator.subscribe(MailResponder.new, with: :successful)
 ```
 
-This is pretty useless unless used in conjuction with `on:`, since all events
+This is pretty useless unless used in conjunction with `on:`, since all events
 will get mapped to `:successful`. Instead you might do something like this:
 
 ```ruby


### PR DESCRIPTION
@krisleech, I've corrected a typographical error in the documentation of the [wisper](https://github.com/krisleech/wisper) project. Specifically, I've changed conjuction to conjunction. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.