### PR TITLE
Support nested temporary listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## HEAD (unreleased)
 
-Authors: Sergey Mostovoy
+Authors: Sergey Mostovoy, Maxim Polunin
 
 * fix: logger raises exception if hash is passed as an argument to a listener
+* fix: support nested temporary global listeners
 
 ## 2.0.0.rc1 (17 Dec 2014)
 

--- a/lib/wisper/temporary_listeners.rb
+++ b/lib/wisper/temporary_listeners.rb
@@ -15,11 +15,12 @@ module Wisper
 
     def subscribe(*listeners, &block)
       options = listeners.last.is_a?(Hash) ? listeners.pop : {}
+      new_registrations = listeners.map { |listener| ObjectRegistration.new(listener, options) }
       begin
-        listeners.each { |listener| registrations << ObjectRegistration.new(listener, options) }
+        registrations.merge new_registrations
         yield
       ensure
-        clear
+        registrations.subtract new_registrations
       end
       self
     end
@@ -29,10 +30,6 @@ module Wisper
     end
 
     private
-
-    def clear
-      registrations.clear
-    end
 
     def key
       '__wisper_temporary_listeners'


### PR DESCRIPTION
If there are multiple places in a code which use temporary global listeners, the first block w/ listeners which leaves cleans all the other listeners from other blocks as well. Example:

```
def foo
  Wisper.subscribe(MyListener.new) do
    bar
  end
end

def bar
  Wisper.subscribe(MyAnotherListener.new) do
    baz
  end
  broadcast(:something) # won't be catched because listeners in `foo` are cleared away
end
```
