### PR TITLE
Added support of custom options in broadcasters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.gem
 *.rbc
 .ruby-version
+.ruby-gemspec
 .bundle
 .config
 .yardoc

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ class OrderNotifier
   def cancel_order_successful(order_id)
     order = Order.find_by_id(order_id)
 
-    # notify someone ...    
+    # notify someone ...
   end
 end
 ```
@@ -115,6 +115,14 @@ this will prevent any subsequent listeners having their events delivered.
 cancel_order.subscribe(OrderNotifier.new, async: true)
 ```
 
+You can also pass additional configuration options to the job using the following syntax:
+
+```ruby
+cancel_order.subscribe(OrderNotifier.new, async: { queue: 'custom', retry: false })
+```
+
+The list of supported handler options is determined by adapter
+
 Wisper has various adapters for asynchronous event handling, please refer to
 [wisper-celluloid](https://github.com/krisleech/wisper-celluloid),
 [wisper-sidekiq](https://github.com/krisleech/wisper-sidekiq),
@@ -131,7 +139,7 @@ class OrderNotifier
   def self.cancel_order_successful(order_id)
     order = Order.find_by_id(order_id)
 
-    # notify someone ...    
+    # notify someone ...
   end
 end
 ```

--- a/lib/wisper/registration/object.rb
+++ b/lib/wisper/registration/object.rb
@@ -9,7 +9,7 @@ module Wisper
       @with   = options[:with]
       @prefix = ValueObjects::Prefix.new options[:prefix]
       @allowed_classes = Array(options[:scope]).map(&:to_s).to_set
-      @broadcaster = map_broadcaster(options[:async] || options[:broadcaster])
+      @broadcaster = map_broadcaster
     end
 
     def broadcast(event, publisher, *args)
@@ -29,11 +29,45 @@ module Wisper
       prefix + (with || event).to_s
     end
 
-    def map_broadcaster(value)
+    # @return [Object] broadcaster instance
+    def map_broadcaster
+      key = broadcaster_key
+      value = options[key]
       return value if value.respond_to?(:broadcast)
-      value = :async   if value == true
-      value = :default if value == nil
-      configuration.broadcasters.fetch(value)
+
+      broadcaster_with_options(key, value)
+    end
+
+    # @return [Symbol] key to fetch broadcaster by
+    #
+    # @example (setup => key)
+    #   publisher.subscribe(Subscriber, async: Wisper::SidekiqBroadcaster.new)       # => :async
+    #   publisher.subscribe(Subscriber, async: true)                                 # => :async
+    #   publisher.subscribe(Subscriber, sidekiq: { queue: 'custom' })                # => :sidekiq
+    #   publisher.subscribe(Subscriber)                                              # => :default
+    #   publisher.subscribe(Subscriber, broadcaster: Wisper::SidekiqBroadcaster.new) # => :broadcaster
+    #   publisher.subscribe(Subscriber, broadcaster: :custom)                        # => :custom
+    #
+    def broadcaster_key
+      return :async if options.has_key?(:async) && options[:async]
+      return :default unless options.has_key?(:broadcaster)
+      options[:broadcaster].is_a?(Symbol) ? options[:broadcaster] : :broadcaster
+    end
+
+    # @param [Symbol] key - param to fetch broadcaster by
+    # @param [Boolean, Nil, Hash, Object] value - broadcaster value. Allowed values are the following:
+    #   nil                 # => default broadcaster
+    #   false               # => default broadcaster
+    #   true                # => async broadcaster
+    #   Broadcaster.new     # => returns the provided broadcaster instance
+    #   { queue: 'custom' } # => is used when broadcaster is configured as a callable object. In this case
+    #                       #    the given options are passed to broadcaster initializer
+    #
+    # @return [Object] broadcaster instance for the given key / value pair
+    #
+    def broadcaster_with_options(key, value)
+      result = configuration.broadcasters.fetch(key)
+      result.respond_to?(:call) ? result.call(value) : result
     end
 
     def configuration

--- a/lib/wisper/registration/registration.rb
+++ b/lib/wisper/registration/registration.rb
@@ -2,10 +2,11 @@
 
 module Wisper
   class Registration
-    attr_reader :on, :listener
+    attr_reader :on, :listener, :options
 
     def initialize(listener, options)
       @listener = listener
+      @options = options
       @on = ValueObjects::Events.new options[:on]
     end
 

--- a/spec/lib/wisper/publisher_spec.rb
+++ b/spec/lib/wisper/publisher_spec.rb
@@ -201,6 +201,26 @@ describe Wisper::Publisher do
           publisher.send(:broadcast, event_name)
         end
       end
+
+      describe 'callable broadcasters' do
+        let(:broadcaster) { Struct.new(:options) }
+        let(:async_options) { { queue: 'custom', retry: false } }
+
+        before do
+          Wisper.configure { |c| c.broadcaster(:async, Proc.new { |options| broadcaster.new(options) }) }
+        end
+
+        it 'initializes broadcaster with configured options during subscribe action' do
+          expect(broadcaster).to receive(:new).with(async_options)
+          publisher.subscribe(listener, async: async_options)
+        end
+
+        it 'invokes configured broadcaster action during event broadcast' do
+          publisher.subscribe(listener, async: async_options)
+          expect_any_instance_of(broadcaster).to receive('broadcast')
+          publisher.send(:broadcast, event_name)
+        end
+      end
     end
 
     it 'returns publisher so methods can be chained' do


### PR DESCRIPTION
Hey folks,

This PR adds ability to pass additional configuration options to broadcasters. It supports all existing configurations + adds ability to pass additional options via the following syntax:

```ruby
cancel_order.subscribe(OrderNotifier.new, async: { queue: 'custom', retry: false })
``` 

In order to accept this options, broadcaster has to be registered as a callable object:

```ruby
config.broadcaster :async, Proc.new { |options| SidekiqBroadcaster.new(options) }
```

Broadcaster's `initializer` has to accept the `options` param and then it will become available in the `broadcast` action:

```ruby
module Wisper
  class SidekiqBroadcaster
    attr_reader :options

    def initialize(options = {})
      @options = options
    end

    def broadcast(subscriber, publisher, event, args)
      subscriber.delay(options).public_send(event, *args)
    end
  end
end
``` 

I have also added support for `sidekiq_options` in the `sidekiq-wisper` adapter here https://github.com/krisleech/wisper-sidekiq/pull/13. 
`wisper-activejob` part is here - https://github.com/krisleech/wisper-activejob/pull/15

We are heavily using your great gem in our systems but that was a killing feature for us that was missing in it. Feel free to consider it. Appreciate any feedback.

Thanks,
Kon.