### PR TITLE
Fix gemspec - Safely expand signing key

### DIFF
--- a/wisper.gemspec
+++ b/wisper.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = "https://github.com/krisleech/wisper"
   gem.license       = "MIT"
 
-  signing_key = File.expand_path('~/.ssh/gem-private_key.pem')
+  signing_key = File.expand_path(ENV['HOME'].to_s + '/.ssh/gem-private_key.pem')
 
   if File.exist?(signing_key)
     gem.signing_key = signing_key


### PR DESCRIPTION
When deploying, I get the following error:

```
There was a ArgumentError while loading wisper.gemspec: 
  couldn't find HOME environment -- expanding `~' from`
```

This PR ensures that the gemspec evaluates correctly if there is even if there is no `$HOME` set