### PR TITLE
Add a license file and slim the gem artifact to just lib/bins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ script: rspec spec
 sudo: false
 rvm:
   - 2.1.10
-  - 2.2.6
-  - 2.3.3
-  - 2.4.0
-  - 2.5.1
+  - 2.2.10
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
   - jruby-9.1.17.0
   # - rbx-2
   ### ALLOWED FAILURES ###

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2013 Kris Leech
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the 'Software'), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/wisper.gemspec
+++ b/wisper.gemspec
@@ -24,8 +24,7 @@ Gem::Specification.new do |gem|
     gem.cert_chain  = ['gem-public_cert.pem']
   end
 
-  gem.files         = `git ls-files`.split($/)
+  gem.files         = %w{LICENSE} + Dir.glob("{lib,bin}/**/*")
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 end


### PR DESCRIPTION
Many projects read in the LICENSE file of a project to perform license
acceptance for dependencies. I've added the license file here. Github
uses this as well to aid in search so it's quite handy. I also slimmed
down the gem by only shipping the lib/bin files in the gem. There's no
need for the docs/test/hidden files in a gem artifact that goes deep in
a filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>