### PR TITLE
Avoid calling to_s on ancestors, which can become expensive and slow

### DIFF
--- a/lib/wisper/registration/object.rb
+++ b/lib/wisper/registration/object.rb
@@ -22,7 +22,7 @@ module Wisper
     private
 
     def publisher_in_scope?(publisher)
-      allowed_classes.empty? || publisher.class.ancestors.any? { |ancestor| allowed_classes.include?(ancestor.to_s) }
+      allowed_classes.empty? || (allowed_classes.map(&:constantize) & publisher.class.ancestors).present?
     end
 
     def map_event_to_method(event)


### PR DESCRIPTION
This is related to issue #168, which I ran into as well.

It appears that the really expensive part of this operation is calling `to_s` on the list of ancestors.

If I change the approach to avoid that operation, things get dramatically faster:

```
# publisher is an activerecord model
Benchmark.bm do |x|
  x.report('any?') { publisher.class.ancestors.any? { |ancestor| allowed_classes.include?(ancestor.to_s) } }
  x.report('&') { (allowed_classes.map(&:constantize) & publisher.class.ancestors).present? }
end

       user     system      total        real
old  0.040000   0.000000   0.040000 (  0.032906)
new  0.000000   0.000000   0.000000 (  0.000201)
```