### PR TITLE
 Fix bug where all temporary listeners cleared when using block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD (unreleased)
 
+Authors: Maxim Polunin
+
+* fix: support nested temporary global listeners
+
 ## 2.0.0 (7th Mar 2017)
 
 Authors: Sergey Mostovoy, Andrew Kozin, Kyle Tolle, Martin, Rob Miller, Mike

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## HEAD (unreleased)
 
-Authors: Maxim Polunin
+Authors: Maxim Polunin, Tristan Harmer
 
 * fix: support nested temporary global listeners
+* docs: add threadsafe notes to README for global and temporary listeners
 
 ## 2.0.0 (7th Mar 2017)
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,8 @@ Wisper.subscribe(MyListener.new)
 
 In a Rails app you might want to add your global listeners in an initalizer.
 
-Global listeners are threadsafe.
+Global listeners are threadsafe. Subscribers will receive events from publishers on current and future threads owned by the ruby process.
+
 
 ### Scoping by publisher class
 
@@ -234,7 +235,7 @@ listeners.
 
 This is useful for capturing events published by objects to which you do not have access in a given context.
 
-Temporary Global Listeners are threadsafe.
+Temporary Global Listeners are threadsafe. Subscribers will receive only events from publishers on the same thread.
 
 ## Subscribing to selected events
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Wisper.subscribe(MyListener.new)
 
 In a Rails app you might want to add your global listeners in an initalizer.
 
-Global listeners are threadsafe. Subscribers will receive events from publishers on current and future threads owned by the ruby process.
+Global listeners are threadsafe. Subscribers will receive events published on all threads.
 
 
 ### Scoping by publisher class
@@ -235,7 +235,7 @@ listeners.
 
 This is useful for capturing events published by objects to which you do not have access in a given context.
 
-Temporary Global Listeners are threadsafe. Subscribers will receive only events from publishers on the same thread.
+Temporary Global Listeners are threadsafe. Subscribers will receive events published on the same thread.
 
 ## Subscribing to selected events
 

--- a/lib/wisper/temporary_listeners.rb
+++ b/lib/wisper/temporary_listeners.rb
@@ -4,7 +4,6 @@
 
 module Wisper
   class TemporaryListeners
-
     def self.subscribe(*listeners, &block)
       new.subscribe(*listeners, &block)
     end
@@ -13,13 +12,14 @@ module Wisper
       new.registrations
     end
 
-    def subscribe(*listeners, &block)
-      options = listeners.last.is_a?(Hash) ? listeners.pop : {}
+    def subscribe(*listeners, &_block)
+      new_registrations = build_registrations(listeners)
+
       begin
-        listeners.each { |listener| registrations << ObjectRegistration.new(listener, options) }
+        registrations.merge new_registrations
         yield
       ensure
-        clear
+        registrations.subtract new_registrations
       end
       self
     end
@@ -30,8 +30,9 @@ module Wisper
 
     private
 
-    def clear
-      registrations.clear
+    def build_registrations(listeners)
+      options = listeners.last.is_a?(Hash) ? listeners.pop : {}
+      listeners.map { |listener| ObjectRegistration.new(listener, options) }
     end
 
     def key


### PR DESCRIPTION
This is a rebuild of #142 off master but with extra documentation. 
Thanks to @0x0badc0de for the code. I tried to cherry pick his commit but it seems to have been deleted since.

The bug bit us and caused us to shift to global listeners with manually managed unsubscribe.
That in turn bit us because we didn't realise the process/thread difference between the two.

Our hope is the added docs will save others this pain in the future 🙏 
Thanks again for the great gem!