### PR TITLE
Remove bin/ executables from gemspec

### DIFF
--- a/wisper.gemspec
+++ b/wisper.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |gem|
   end
 
   gem.files         = `git ls-files`.split($/)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 end


### PR DESCRIPTION
See https://bundler.io/blog/2015/03/20/moving-bins-to-exe.html

Here's a similar PR on another gem: https://github.com/hexorx/countries/pull/571

Note that if both gems, `countries` and `wisper`, get installed in the same setup,
they end up conflicting with each other:

```sh
$ gem install cp8_cli
wisper's executable "console" conflicts with countries
Overwrite the executable? [yN]  N
ERROR:  Error installing cp8_cli:
        "console" from wisper conflicts with installed executable from
	countries
```