### PR TITLE
Minimize calling to_s on class ancestors

### DIFF
--- a/lib/wisper/registration/object.rb
+++ b/lib/wisper/registration/object.rb
@@ -8,7 +8,7 @@ module Wisper
       super(listener, options)
       @with   = options[:with]
       @prefix = ValueObjects::Prefix.new options[:prefix]
-      @allowed_classes = Array(options[:scope]).map(&:to_s).to_set
+      @allowed_classes = normalize_classes(Array(options[:scope]))
       @broadcaster = map_broadcaster(options[:async] || options[:broadcaster])
     end
 
@@ -22,7 +22,24 @@ module Wisper
     private
 
     def publisher_in_scope?(publisher)
-      allowed_classes.empty? || publisher.class.ancestors.any? { |ancestor| allowed_classes.include?(ancestor.to_s) }
+      anonymous_ancestors = nil
+
+      allowed_classes.empty? || allowed_classes.any? do |klass|
+        if klass.is_a?(String)
+          # NOTE: This conditional branch contains expensive and time-consuming operations.
+          #       Avoid this branch if possible.
+
+          if anonymous_ancestors.nil?
+            # A class without a name is an anonymous class.
+            anonymous_ancestors = publisher.class.ancestors.select { |ancestor| ancestor.name.blank? }
+            anonymous_ancestors.map!(&:to_s)
+          end
+
+          anonymous_ancestors.include?(klass)
+        else
+          publisher.class.ancestors.include?(klass)
+        end
+      end
     end
 
     def map_event_to_method(event)
@@ -38,6 +55,24 @@ module Wisper
 
     def configuration
       Wisper.configuration
+    end
+
+    def normalize_classes(classes)
+      classes = classes.dup
+      classes.map! do |klass|
+        next klass if klass.is_a?(Module)
+
+        klass = klass.to_s
+
+        begin
+          Object.const_get(klass)
+        rescue NameError
+          klass
+        end
+      end
+      classes.select!(&:present?)
+      classes.uniq!
+      classes
     end
   end
 end

--- a/spec/lib/wisper/registrations/object_spec.rb
+++ b/spec/lib/wisper/registrations/object_spec.rb
@@ -1,14 +1,74 @@
 describe Wisper::ObjectRegistration do
+  let(:listener) { double('listener') }
 
   describe 'broadcaster' do
     it 'defaults to SendBroadcaster' do
-      subject = Wisper::ObjectRegistration.new(double('listener'), {})
+      subject = Wisper::ObjectRegistration.new(listener, {})
       expect(subject.broadcaster).to be_instance_of(Wisper::Broadcasters::SendBroadcaster)
     end
 
     it 'default is lazily evaluated' do
       expect(Wisper::Broadcasters::SendBroadcaster).to_not receive :new
-      Wisper::ObjectRegistration.new(double('listener'), broadcaster: double('DifferentBroadcaster').as_null_object)
+      Wisper::ObjectRegistration.new(listener, broadcaster: double('DifferentBroadcaster').as_null_object)
+    end
+  end
+
+  describe 'allowed_classes' do
+    subject { Wisper::ObjectRegistration.new(listener, scope: scope) }
+
+    let(:anonymous_class_1) { publisher_class }
+    let(:anonymous_class_2) { publisher_class }
+    let(:anonymous_module_1) { publisher_module }
+    let(:anonymous_module_2) { publisher_module }
+    let(:scope) do
+      [
+        Publisher1, 'Publisher2', Publisher3, 'Publisher4',
+        anonymous_class_1, anonymous_class_2.to_s, anonymous_module_1, anonymous_module_2.to_s,
+        nil, '', '   '
+      ]
+    end
+
+    before do
+      Publisher1 = publisher_class
+      Publisher2 = publisher_class
+      Publisher3 = publisher_module
+      Publisher4 = publisher_module
+    end
+
+    after do
+      Object.send(:remove_const, :Publisher1)
+      Object.send(:remove_const, :Publisher2)
+      Object.send(:remove_const, :Publisher3)
+      Object.send(:remove_const, :Publisher4)
+    end
+
+    it 'contains constant/anonymous classes/modules' do
+      expect(subject.allowed_classes).to contain_exactly(
+        Publisher1,
+        Publisher2,
+        Publisher3,
+        Publisher4,
+        anonymous_class_1,
+        anonymous_class_2.to_s,
+        anonymous_module_1,
+        anonymous_module_2.to_s
+      )
+    end
+
+    context 'when scope contains duplicated classes' do
+      let(:scope) { [Publisher1, 'Publisher1'] }
+
+      it 'does not contain duplicated classes' do
+        expect(subject.allowed_classes.length).to eq(1)
+      end
+    end
+
+    context 'when scope contains nil or blank strings' do
+      let(:scope) { [nil, '', '   '] }
+
+      it 'does not contain anything' do
+        expect(subject.allowed_classes.length).to eq(0)
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,21 @@ Coveralls.wear!
 
 require 'wisper'
 
+module PublisherHelpers
+  # returns an anonymous wispered class
+  def publisher_class
+    Class.new { include Wisper::Publisher }
+  end
+
+  # returns an anonymous wispered module
+  def publisher_module
+    Module.new { include Wisper::Publisher }
+  end
+end
+
 RSpec.configure do |config|
+  config.include PublisherHelpers
+
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
   config.order = 'random'
@@ -16,9 +30,4 @@ RSpec.configure do |config|
   config.mock_with :rspec do |c|
     c.syntax = :expect
   end
-end
-
-# returns an anonymous wispered class
-def publisher_class
-  Class.new { include Wisper::Publisher }
 end


### PR DESCRIPTION
This PR is a follow-up of #174 and it solves issue with anonymous class string. It doesn't avoid calling `to_s` completely, but only calls `to_s` when `allowed_classes` contains a string like `#<Class:0xXXXXXX>`.