### PR TITLE
Issue #180 - exclude bin directory from gem

### DIFF
--- a/wisper.gemspec
+++ b/wisper.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
     gem.cert_chain  = ['gem-public_cert.pem']
   end
 
-  gem.files         = `git ls-files`.split($/)
+  gem.files         = `git ls-files`.split($/).reject { |f| /^bin\// === f }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 end

--- a/wisper.gemspec
+++ b/wisper.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
     gem.cert_chain  = ['gem-public_cert.pem']
   end
 
-  gem.files         = `git ls-files`.split($/).reject { |f| /^bin\// === f }
+  gem.files         = `git ls-files`.split($/).reject { |f| f.split('/').first == 'bin' }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 end


### PR DESCRIPTION
This PR would remove the `bin` directory from the built gem. Addresses issue #180.