### PR TITLE
remove bin/ executables from built gem

### DIFF
--- a/wisper.gemspec
+++ b/wisper.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split($/).reject { |f| f.split('/').first == 'bin' }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
+  gem.executables   = []
 end


### PR DESCRIPTION
Having scripts under `bin` without removing them from your gems executables makes them available when gem is installed.