### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## HEAD (unreleased)
 
+Authors: Keith Bennett
+
+* fix: exclude bin directory from gem #181
+
 ## 2.0.1 (29th Aug 2019)
 
 Authors: David Wilkie, hosseintoussi, Maxim Polunin, Tristan


### PR DESCRIPTION
Wisper now conflicts with json-jwt (1.15.0). Releasing the existing state of master would fix this.