### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ Authors: Kris Leech
 Authors: Kris Leech
 
 * feature: allow events to be published asynchronously
-* feature: broadcasting of events is plugable and configurable
+* feature: broadcasting of events is pluggable and configurable
 * feature: broadcasters can be aliased via a symbol
 * feature: logging broadcaster
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ and contributors are expected to adhere to the
 
 Please first check the existing [Issues](https://github.com/krisleech/wisper/issues) 
 and [Pull Requests](https://github.com/krisleech/wisper/pulls) to ensure your
-issue has not already been discused.
+issue has not already been discussed.
 
 ## Bugs
 
@@ -20,7 +20,7 @@ and Ruby you are using and a small code sample (or better yet a failing test).
 ## Features
 
 Please open an issue with your proposed feature. We can discuss the feature and
-if it is acceptable we can also discuss implimentation details. You will in
+if it is acceptable we can also discuss implementation details. You will in
 most cases have to submit a PR which adds the feature. 
 
 Wisper is a micro library and will remain lean. Some features would be most

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 * Connect objects based on context without permanence
 * Publish events synchronously or asynchronously
 
-Note: Wisper was originally extracted from a Rails codebase but is not dependant on Rails.
+Note: Wisper was originally extracted from a Rails codebase but is not dependent on Rails.
 
 Please also see the [Wiki](https://github.com/krisleech/wisper/wiki) for more additional information and articles.
 

--- a/spec/lib/wisper/publisher_spec.rb
+++ b/spec/lib/wisper/publisher_spec.rb
@@ -114,19 +114,19 @@ describe Wisper::Publisher do
       let(:listener_2) { double('Listener') }
 
       it 'scopes listener to given class' do
-        expect(listener_1).to receive(:it_happended)
-        expect(listener_2).not_to receive(:it_happended)
+        expect(listener_1).to receive(:it_happened)
+        expect(listener_2).not_to receive(:it_happened)
         publisher.subscribe(listener_1, :scope => publisher.class)
         publisher.subscribe(listener_2, :scope => Class.new)
-        publisher.send(:broadcast, 'it_happended')
+        publisher.send(:broadcast, 'it_happened')
       end
 
       it 'scopes listener to given class string' do
-        expect(listener_1).to receive(:it_happended)
-        expect(listener_2).not_to receive(:it_happended)
+        expect(listener_1).to receive(:it_happened)
+        expect(listener_2).not_to receive(:it_happened)
         publisher.subscribe(listener_1, :scope => publisher.class.to_s)
         publisher.subscribe(listener_2, :scope => Class.new.to_s)
-        publisher.send(:broadcast, 'it_happended')
+        publisher.send(:broadcast, 'it_happened')
       end
 
       it 'includes all subclasses of given class' do
@@ -134,12 +134,12 @@ describe Wisper::Publisher do
         publisher_sub_klass = Class.new(publisher_super_klass)
 
         listener = double('Listener')
-        expect(listener).to receive(:it_happended).once
+        expect(listener).to receive(:it_happened).once
 
         publisher = publisher_sub_klass.new
 
         publisher.subscribe(listener, :scope => publisher_super_klass)
-        publisher.send(:broadcast, 'it_happended')
+        publisher.send(:broadcast, 'it_happened')
       end
     end
 


### PR DESCRIPTION
Found via `codespell -L wisper,wispered` and `typos --format brief`