### PR TITLE
Exclude spec files from gem package

### DIFF
--- a/wisper.gemspec
+++ b/wisper.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
     gem.cert_chain  = ['gem-public_cert.pem']
   end
 
-  gem.files         = `git ls-files`.split($/).reject { |f| f.split('/').first == 'bin' }
+  gem.files         = `git ls-files`.split($/).reject { |f| f.start_with?(%r{(bin|spec)/}) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 end


### PR DESCRIPTION
Here's a patch that excludes files under spec directory from the gem package.

With this patch, the gem package size shrinks as follows:
```
before: 22528 bytes
after:  14336 bytes
```